### PR TITLE
Move fetch() to lib

### DIFF
--- a/bin/setup.js
+++ b/bin/setup.js
@@ -46,7 +46,7 @@ function setup (rootDir, includes, opts, cb) {
   if (!fs.existsSync(dstDir)) fs.mkdirSync(dstDir)
   if (!fs.existsSync(filesDir)) fs.mkdirSync(filesDir)
 
-  copyAsHash(rootDir, includes, dstDir, filesDir, function (err, mappings) {
+  copyAsHash(includes, dstDir, filesDir, function (err, mappings) {
     if (err) return cb(err)
 
     let torrentFiles = mappings.map(e => absPath(e.dst))
@@ -79,7 +79,7 @@ function writeManifestSync (srcDir, dstDir, filesDir, mappings) {
   fs.writeFileSync(dstDir + '/manifest.json', buff)
 }
 
-function copyAsHash (rootDir, srcList, dstDir, filesDir, cb) {
+function copyAsHash (srcList, dstDir, filesDir, cb) {
   let files = []
 
   for (let item of srcList) {

--- a/bin/setup.js
+++ b/bin/setup.js
@@ -36,6 +36,7 @@ function setup (rootDir, includes, opts, cb) {
   rootDir = absPath(rootDir)
   includes = includes.map(p => absPath(p))
   const dstDir = rootDir + '/' + RESERVED_DIR
+  const filesDir = dstDir + '/files'
   if (!opts) opts = {}
 
   if (includes.find(f => !isNested(rootDir, f))) {
@@ -43,16 +44,17 @@ function setup (rootDir, includes, opts, cb) {
   }
 
   if (!fs.existsSync(dstDir)) fs.mkdirSync(dstDir)
+  if (!fs.existsSync(filesDir)) fs.mkdirSync(filesDir)
 
-  copyAsHash(rootDir, includes, dstDir, function (err, mappings) {
+  copyAsHash(rootDir, includes, dstDir, filesDir, function (err, mappings) {
     if (err) return cb(err)
 
     let torrentFiles = mappings.map(e => absPath(e.dst))
 
     // From BitTorrent Documentation: "In the single file case, the name key is the name of
     // a file, in the multiple file case, it's the name of a directory."
-    opts.name = torrentFiles.length === 1
-        ? torrentFiles[0].slice(torrentFiles[0].lastIndexOf('/') + 1) : RESERVED_DIR
+    opts.name = torrentFiles.length !== 1 ? RESERVED_DIR + '/files'
+        : torrentFiles[0].slice(torrentFiles[0].lastIndexOf('/') + 1)
 
     createTorrent(torrentFiles, opts, function (err, torrent) {
       if (err) return cb(err)
@@ -61,23 +63,23 @@ function setup (rootDir, includes, opts, cb) {
         if (err) return cb(err)
 
         fs.writeFileSync(dstDir + '/root.torrent', torrent)
-        writeManifestSync(rootDir, dstDir, mappings)
+        writeManifestSync(rootDir, dstDir, filesDir, mappings)
         cb(null)
       })
     })
   })
 }
 
-function writeManifestSync (srcDir, dstDir, mappings) {
+function writeManifestSync (srcDir, dstDir, filesDir, mappings) {
   let relMappings = {}
   for (let map of mappings) {
-    relMappings[map.src.substr(srcDir.length + 1)] = map.dst.substr(dstDir.length + 1)
+    relMappings[map.src.substr(srcDir.length + 1)] = map.dst.substr(filesDir.length + 1)
   }
   let buff = new Buffer(JSON.stringify(relMappings))
   fs.writeFileSync(dstDir + '/manifest.json', buff)
 }
 
-function copyAsHash (rootDir, srcList, dstDir, cb) {
+function copyAsHash (rootDir, srcList, dstDir, filesDir, cb) {
   let files = []
 
   for (let item of srcList) {
@@ -85,7 +87,7 @@ function copyAsHash (rootDir, srcList, dstDir, cb) {
   }
 
   let tasks = files.map(fname => {
-    return function (cc) { copyFileAsHash(fname, dstDir, cc) }
+    return function (cc) { copyFileAsHash(fname, filesDir, cc) }
   })
   parallelLimit(tasks, FS_CONCURRENCY, cb)
 }

--- a/index.js
+++ b/index.js
@@ -77,11 +77,11 @@ function fetch (req, opts) {
     modUrl.search = (url.search === '' ? '?' : url.search + '&') + 'noPlanktosInjection'
     let html = (isHTML ? injection.docWrite : injection.iframe)
                .replace('{{url}}', modUrl.toString())
-               .replace('{{scope}}', opts.scope ? opts.scope : '')
+               .replace('{{root}}', opts.root ? opts.root : '')
     blobPromise = Promise.resolve(new Blob([html], {type: 'text/html'}))
   } else {
-    // fpath is relative to the service worker scope if opts.scope was given
-    let fpath = opts.scope ? url.pathname.replace(opts.scope, '') : url.pathname
+    // fpath is relative to the service worker scope if opts.root was given
+    let fpath = opts.root ? url.pathname.replace(opts.root, '') : url.pathname
 
     blobPromise = Promise.all([
       global.caches.open('planktos')

--- a/index.js
+++ b/index.js
@@ -54,7 +54,7 @@ function fetch (req, opts) {
 
   // Convert a FetchEvent to Request
   if (global.FetchEvent && req instanceof global.FetchEvent) {
-    inject = req.clientId == null
+    inject = req.clientId == null // This is the initial request of a new webpage
     req = req.request // req is now an instance of Request
   }
 
@@ -70,7 +70,7 @@ function fetch (req, opts) {
     url = new URL(req)
   }
 
-  if (req == null) throw new Error('Must provide a FetchEvent, Request, URL, or a string')
+  if (url == null) throw new Error('Must provide a FetchEvent, Request, URL, or a url string')
   if (url.origin !== global.location.origin) throw new Error('Cannot Fetch. Origin differs')
 
   inject = 'inject' in opts ? opts.inject : inject
@@ -83,7 +83,7 @@ function fetch (req, opts) {
     let fname = url.pathname.substr(url.pathname.lastIndexOf('/') + 1)
     const isHTML = fname.endsWith('.html') || fname.endsWith('.htm') || !fname.includes('.')
     let modUrl = new URL(url.toString())
-    modUrl.search = (url.search === '' ? '?' : url.search + '&') + 'noPlanktosInjection'
+    modUrl.search = (modUrl.search === '' ? '?' : modUrl.search + '&') + 'noPlanktosInjection'
     let html = (isHTML ? injection.docWrite : injection.iframe)
                .replace('{{url}}', modUrl.toString())
                .replace('{{root}}', opts.root ? opts.root : '')
@@ -95,9 +95,9 @@ function fetch (req, opts) {
     blobPromise = Promise.all([
       global.caches.open('planktos')
         .then(c => c.match(path.normalize(url.pathname)))
-        .then(r => r ? r.blob() : undefined),
+        .then(resp => resp ? resp.blob() : undefined),
       getFile(fpath)
-        .then(f => f ? f.getBlob() : undefined)
+        .then(file => file ? file.getBlob() : undefined)
     ]).then(blobs => blobs.find(b => b != null))
   }
 

--- a/lib/downloader.js
+++ b/lib/downloader.js
@@ -71,7 +71,7 @@ function download (torrentId) {
       const swUrl = navigator.serviceWorker.controller.scriptURL
 
       let webSeedUrl = swUrl.substring(0, swUrl.lastIndexOf('/'))
-      if (isSingleFile) webSeedUrl += '/planktos/' + torrent.files[0].name
+      if (isSingleFile) webSeedUrl += '/planktos/files/' + torrent.files[0].name
 
       torrent.addWebSeed(webSeedUrl)
     }

--- a/lib/downloader.js
+++ b/lib/downloader.js
@@ -1,6 +1,5 @@
 module.exports.install = install
 
-require('debug').enable('planktos:*')
 const debug = require('debug')('planktos:downloader')
 const WebTorrent = require('webtorrent')
 const IdbChunkStore = require('indexeddb-chunk-store')

--- a/lib/file.js
+++ b/lib/file.js
@@ -19,14 +19,15 @@ function getFile (planktos, fpath) {
     let [manifest, torrentMeta] = result
 
     // If the `fpath` cannot be found in the manifest, try to search for the index file
-    fpath = planktos._normalizePath(fpath)
+    fpath = normalizePath(fpath)
     fpath = ['', 'index.html', 'index.htm']
                .map(name => path.join(fpath, name))
                .find(fpath => fpath in manifest)
     let hash = manifest[fpath]
     let fileInfo = torrentMeta.files.find(f => f.name === hash)
 
-    if (!fileInfo) throw new Error('File not found')
+    // File not found
+    if (!fileInfo) return Promise.resolve(undefined)
 
     return new File(fpath, fileInfo, torrentMeta)
   })
@@ -91,4 +92,11 @@ function onChunkPut (change) {
     delete missingChunks[change.key]
     retries.forEach(retry => retry())
   }
+}
+
+function normalizePath (filePath) {
+  filePath = path.normalize(filePath)
+  if (filePath.startsWith('/')) filePath = filePath.substr(1)
+  if (filePath === '.') filePath = ''
+  return filePath
 }

--- a/lib/injection.js
+++ b/lib/injection.js
@@ -12,7 +12,7 @@ module.exports.iframe = `\
 </head>
 <body>
   <iframe id="tree" name="tree" src="{{url}}" frameborder="0" marginheight="0" marginwidth="0" width="100%" height="100%" scrolling="auto"></iframe>
-  <script src="{{scope}}/planktos/planktos.min.js"></script>
+  <script src="{{root}}/planktos/planktos.min.js"></script>
   <script>
     planktos.downloader.install()
   </script>
@@ -25,7 +25,7 @@ module.exports.docWrite = `\
 <html>
 <head>
   <meta charset="utf-8">
-  <script src="{{scope}}/planktos/planktos.min.js"></script>
+  <script src="{{root}}/planktos/planktos.min.js"></script>
   <script>
     planktos.downloader.install()
     fetch('{{url}}')

--- a/sw.js
+++ b/sw.js
@@ -3,7 +3,7 @@
 const planktos = require('.')
 
 // The location of the planktos root directory
-const scope = location.pathname.substring(0, location.pathname.lastIndexOf('/'))
+const root = location.pathname.substring(0, location.pathname.lastIndexOf('/'))
 let available = {}
 let delegator = null
 
@@ -23,7 +23,7 @@ function onFetch (event) {
   assignDelegator()
 
   // Fallback to browser http if the file was not found in the torrent or an error occures
-  let promise = planktos.fetch(event, {scope: scope})
+  let promise = planktos.fetch(event, {root: root})
   .then(response => response != null ? response : fetch(event.request))
   .catch(err => {
     console.log('PLANKTOS-ERROR', err)
@@ -34,7 +34,7 @@ function onFetch (event) {
 }
 
 function onInstall (event) {
-  event.waitUntil(planktos.update(scope).then(() => console.log('PLANKTOS-INSTALLED')))
+  event.waitUntil(planktos.update(root).then(() => console.log('PLANKTOS-INSTALLED')))
 }
 
 function onMessage (event) {

--- a/sw.js
+++ b/sw.js
@@ -17,13 +17,15 @@ function onFetch (event) {
   let url = new URL(event.request.url)
 
   if (url.host !== location.host || event.request.method !== 'GET') return
+
+  // Let the browser handle webseed requests for performance reasons
   if (url.pathname.replace(root, '').startsWith('/planktos/files/')) return
 
   console.log('PLANKTOS-FETCH', 'url=' + url.pathname)
 
   assignDelegator()
 
-  // Fallback to browser http if the file was not found in the torrent or an error occures
+  // Fallback to browser http if the file was not found in the torrent or an error occurs
   let responsePromise = planktos.fetch(event, {root: root})
   .then(response => response != null ? response : fetch(event.request))
   .catch(err => {

--- a/sw.js
+++ b/sw.js
@@ -17,20 +17,21 @@ function onFetch (event) {
   let url = new URL(event.request.url)
 
   if (url.host !== location.host || event.request.method !== 'GET') return
+  if (url.pathname.replace(root, '').startsWith('/planktos/files/')) return
 
   console.log('PLANKTOS-FETCH', 'url=' + url.pathname)
 
   assignDelegator()
 
   // Fallback to browser http if the file was not found in the torrent or an error occures
-  let promise = planktos.fetch(event, {root: root})
+  let responsePromise = planktos.fetch(event, {root: root})
   .then(response => response != null ? response : fetch(event.request))
   .catch(err => {
     console.log('PLANKTOS-ERROR', err)
     return fetch(event.request)
   })
 
-  event.respondWith(promise)
+  event.respondWith(responsePromise)
 }
 
 function onInstall (event) {

--- a/test/test.js
+++ b/test/test.js
@@ -108,28 +108,28 @@ describe('sanity check', function () {
   })
 
   it('planktos.fetch()', function () {
-    return planktos.fetch(new Request(base + 'foobar.txt'), {scope: base})
+    return planktos.fetch(new Request(base + 'foobar.txt'), {root: base})
     .then(response => response.blob())
     .then(blob => blobToText(blob))
     .then(text => assert(text, 'foobar\n'))
   })
 
   it('planktos.fetch() - non normalized url', function () {
-    return planktos.fetch(new Request(base + '///.////foobar.txt'), {scope: base})
+    return planktos.fetch(new Request(base + '///.////foobar.txt'), {root: base})
     .then(response => response.blob())
     .then(blob => blobToText(blob))
     .then(text => assert(text, 'foobar\n'))
   })
 
   it('planktos.fetch() with string', function () {
-    return planktos.fetch(location.origin + base + 'foobar.txt', {scope: base})
+    return planktos.fetch(location.origin + base + 'foobar.txt', {root: base})
     .then(response => response.blob())
     .then(blob => blobToText(blob))
     .then(text => assert(text, 'foobar\n'))
   })
 
   it('planktos.fetch() implied index html', function () {
-    return planktos.fetch(location.origin + base + 'foo', {scope: base})
+    return planktos.fetch(location.origin + base + 'foo', {root: base})
     .then(response => response.blob())
     .then(blob => blobToText(blob))
     .then(text => assert(text, 'bar\n'))
@@ -137,21 +137,21 @@ describe('sanity check', function () {
 
   it('planktos.fetch() with invalid request', function () {
     assert.throws(() => {
-      planktos.fetch({}, {scope: base})
+      planktos.fetch({}, {root: base})
     })
     assert.throws(() => {
-      planktos.fetch(null, {scope: base})
+      planktos.fetch(null, {root: base})
     })
     assert.throws(() => {
-      planktos.fetch('http://example.com' + base + 'foobar.txt', {scope: base})
+      planktos.fetch('http://example.com' + base + 'foobar.txt', {root: base})
     })
     assert.throws(() => {
-      planktos.fetch(new Request(base + 'foobar.txt', {method: 'POST'}), {scope: base})
+      planktos.fetch(new Request(base + 'foobar.txt', {method: 'POST'}), {root: base})
     })
   })
 
   it('planktos.fetch() and inject for non-html files', function () {
-    return planktos.fetch(location.origin + base + 'foobar.txt', {scope: base, inject: true})
+    return planktos.fetch(location.origin + base + 'foobar.txt', {root: base, inject: true})
     .then(response => response.blob())
     .then(blob => blobToText(blob))
     .then(text => {
@@ -161,7 +161,7 @@ describe('sanity check', function () {
   })
 
   it('planktos.fetch() and inject for html files', function () {
-    return planktos.fetch(location.origin + base + 'foo/', {scope: base, inject: true})
+    return planktos.fetch(location.origin + base + 'foo/', {root: base, inject: true})
     .then(response => response.blob())
     .then(blob => blobToText(blob))
     .then(text => {
@@ -178,7 +178,7 @@ describe('sanity check', function () {
       base + 'planktos/install.js'
     ]
     return Promise.all(preCached.map(fpath => {
-      return planktos.fetch(new Request(fpath), {scope: base})
+      return planktos.fetch(new Request(fpath), {root: base})
     }))
     .then(responses => responses.forEach(r => {
       assert.notEqual(r, undefined)

--- a/test/test.js
+++ b/test/test.js
@@ -4,6 +4,8 @@
 const assert = require('assert')
 const parseTorrent = require('parse-torrent-file')
 
+localStorage.debug = 'planktos*'
+
 describe('sanity check', function () {
   this.timeout(20000)
 

--- a/test/test.js
+++ b/test/test.js
@@ -111,28 +111,28 @@ describe('sanity check', function () {
     return planktos.fetch(new Request(base + 'foobar.txt'), {root: base})
     .then(response => response.blob())
     .then(blob => blobToText(blob))
-    .then(text => assert(text, 'foobar\n'))
+    .then(text => assert.equal(text, 'foobar\n'))
   })
 
   it('planktos.fetch() - non normalized url', function () {
     return planktos.fetch(new Request(base + '///.////foobar.txt'), {root: base})
     .then(response => response.blob())
     .then(blob => blobToText(blob))
-    .then(text => assert(text, 'foobar\n'))
+    .then(text => assert.equal(text, 'foobar\n'))
   })
 
   it('planktos.fetch() with string', function () {
     return planktos.fetch(location.origin + base + 'foobar.txt', {root: base})
     .then(response => response.blob())
     .then(blob => blobToText(blob))
-    .then(text => assert(text, 'foobar\n'))
+    .then(text => assert.equal(text, 'foobar\n'))
   })
 
   it('planktos.fetch() implied index html', function () {
     return planktos.fetch(location.origin + base + 'foo', {root: base})
     .then(response => response.blob())
     .then(blob => blobToText(blob))
-    .then(text => assert(text, 'bar\n'))
+    .then(text => assert.equal(text, 'bar\n'))
   })
 
   it('planktos.fetch() with invalid request', function () {

--- a/test/test.js
+++ b/test/test.js
@@ -1,4 +1,4 @@
-/* eslint-env mocha */
+/* eslint-env mocha, browser */
 /* global planktos */
 
 const assert = require('assert')
@@ -58,12 +58,17 @@ describe('sanity check', function () {
     })
   })
 
+  it('getFile() - non normalized url', function () {
+    return planktos.getFile('///.//foo////')
+    .then(f => assert.equal(f.path, 'foo/index.html'))
+  })
+
   it('file.getStream()', function () {
     return planktos.getFile('foobar.txt')
     .then(f => f.getStream())
     .then(stream => {
       return new Promise(resolve => {
-        var buffer = Buffer.alloc(0)
+        let buffer = Buffer.alloc(0)
         stream.on('data', chunk => {
           buffer = Buffer.concat([buffer, chunk])
         })
@@ -79,14 +84,6 @@ describe('sanity check', function () {
     return planktos.getFile('foobar.txt')
     .then(f => f.getBlob())
     .then(blob => blobToText(blob))
-    .then(text => {
-      assert.equal(text, 'foobar\n')
-    })
-  })
-
-  it('fetch()', function () {
-    return iframe.contentWindow.fetch(base + 'foobar.txt')
-    .then(resp => resp.text())
     .then(text => {
       assert.equal(text, 'foobar\n')
     })
@@ -110,9 +107,108 @@ describe('sanity check', function () {
     })
   })
 
+  it('planktos.fetch()', function () {
+    return planktos.fetch(new Request(base + 'foobar.txt'), {scope: base})
+    .then(response => response.blob())
+    .then(blob => blobToText(blob))
+    .then(text => assert(text, 'foobar\n'))
+  })
+
+  it('planktos.fetch() - non normalized url', function () {
+    return planktos.fetch(new Request(base + '///.////foobar.txt'), {scope: base})
+    .then(response => response.blob())
+    .then(blob => blobToText(blob))
+    .then(text => assert(text, 'foobar\n'))
+  })
+
+  it('planktos.fetch() with string', function () {
+    return planktos.fetch(location.origin + base + 'foobar.txt', {scope: base})
+    .then(response => response.blob())
+    .then(blob => blobToText(blob))
+    .then(text => assert(text, 'foobar\n'))
+  })
+
+  it('planktos.fetch() implied index html', function () {
+    return planktos.fetch(location.origin + base + 'foo', {scope: base})
+    .then(response => response.blob())
+    .then(blob => blobToText(blob))
+    .then(text => assert(text, 'bar\n'))
+  })
+
+  it('planktos.fetch() with invalid request', function () {
+    assert.throws(() => {
+      planktos.fetch({}, {scope: base})
+    })
+    assert.throws(() => {
+      planktos.fetch(null, {scope: base})
+    })
+    assert.throws(() => {
+      planktos.fetch('http://example.com' + base + 'foobar.txt', {scope: base})
+    })
+    assert.throws(() => {
+      planktos.fetch(new Request(base + 'foobar.txt', {method: 'POST'}), {scope: base})
+    })
+  })
+
+  it('planktos.fetch() and inject for non-html files', function () {
+    return planktos.fetch(location.origin + base + 'foobar.txt', {scope: base, inject: true})
+    .then(response => response.blob())
+    .then(blob => blobToText(blob))
+    .then(text => {
+      assert(text.startsWith('<!doctype html>'))
+      assert(text.includes('<iframe'))
+    })
+  })
+
+  it('planktos.fetch() and inject for html files', function () {
+    return planktos.fetch(location.origin + base + 'foo/', {scope: base, inject: true})
+    .then(response => response.blob())
+    .then(blob => blobToText(blob))
+    .then(text => {
+      assert(text.startsWith('<!doctype html>'))
+      assert(text.includes('document.documentElement.innerHTML = '))
+    })
+  })
+
+  it('planktos.fetch() preCached', function () {
+    let preCached = [
+      base + 'planktos/root.torrent',
+      base + 'planktos/manifest.json',
+      base + 'planktos/planktos.min.js',
+      base + 'planktos/install.js'
+    ]
+    return Promise.all(preCached.map(fpath => {
+      return planktos.fetch(new Request(fpath), {scope: base})
+    }))
+    .then(responses => responses.forEach(r => {
+      assert.notEqual(r, undefined)
+    }))
+  })
+
+  it('planktos.fetch() preCached non normalized url', function () {
+    return planktos.fetch(new Request(base + '//planktos/./root.torrent'))
+    .then(response => assert.notEqual(response, undefined))
+  })
+
+  it('window.fetch()', function () {
+    return iframe.contentWindow.fetch(base + 'foobar.txt')
+    .then(resp => resp.text())
+    .then(text => {
+      assert.equal(text, 'foobar\n')
+    })
+  })
+
+  it('window.fetch() implied index html', function () {
+    return iframe.contentWindow.fetch(base + 'foo')
+    .then(resp => resp.text())
+    .then(text => {
+      assert.equal(text, 'bar\n')
+    })
+  })
+
   it('getFile() - file does not exist', function () {
     return planktos.getFile('/doesNotExist.html')
-    .catch(err => assert.equal(err.message, 'File not found'))
+    .then(file => assert.equal(file, undefined))
   })
 
   it('no iframe injected into html', function () {

--- a/test/testCli.js
+++ b/test/testCli.js
@@ -26,13 +26,13 @@ describe('sanity', function () {
         let manifest = JSON.parse(getContents('planktos/manifest.json').toString())
 
         Object.keys(manifest).forEach((relPath) => {
-          assert(manifest[relPath] === pathToHash[relPath])
+          assert.equal(manifest[relPath], pathToHash[relPath])
         })
 
         checkTorrent(rootDir, pathToContents, pathToHash)
 
-        assert(getContents('/planktos/' + pathToHash['foo.txt']).equals(new Buffer(pathToContents['foo.txt'])))
-        assert(getContents('/planktos/' + pathToHash['dir/nested.txt']).equals(new Buffer(pathToContents['dir/nested.txt'])))
+        assert(getContents('/planktos/files/' + pathToHash['foo.txt']).equals(new Buffer(pathToContents['foo.txt'])))
+        assert(getContents('/planktos/files/' + pathToHash['dir/nested.txt']).equals(new Buffer(pathToContents['dir/nested.txt'])))
         assert.notEqual(getContents('/planktos/install.js').length, 0)
         assert.notEqual(getContents('/planktos/planktos.min.js').length, 0)
         assert.notEqual(getContents('/planktos.sw.min.js').length, 0)
@@ -66,7 +66,7 @@ describe('single file torrent', function () {
 
         checkTorrent(rootDir, pathToContents, pathToHash)
 
-        assert(getContents('/planktos/' + pathToHash['foo.txt']).equals(new Buffer(pathToContents['foo.txt'])))
+        assert(getContents('/planktos/files/' + pathToHash['foo.txt']).equals(new Buffer(pathToContents['foo.txt'])))
         assert.notEqual(getContents('/planktos/install.js').length, 0)
         assert.notEqual(getContents('/planktos/planktos.min.js').length, 0)
         assert.notEqual(getContents('/planktos.sw.min.js').length, 0)
@@ -88,7 +88,7 @@ function checkTorrent (rootDir, pathToContents, pathToHash) {
   const isSingleFileTorrent = torrentMeta.files.length === 1
 
   // If the torrent is a single file torrent its name should be the hash of the first file
-  assert.equal(torrentMeta.name, (!isSingleFileTorrent) ? 'planktos' : pathToHash[Object.keys(pathToHash)[0]])
+  assert.equal(torrentMeta.name, (!isSingleFileTorrent) ? 'planktos/files' : pathToHash[Object.keys(pathToHash)[0]])
   assert.notEqual(torrentMeta.announce.length, 0)
 
   assert.deepEqual(
@@ -98,7 +98,7 @@ function checkTorrent (rootDir, pathToContents, pathToHash) {
   assert.deepEqual(
     torrentMeta.files.map((f) => f.path),
     orderedRelFiles.map((relFile) => {
-      if (!isSingleFileTorrent) return 'planktos/' + pathToHash[relFile]
+      if (!isSingleFileTorrent) return 'planktos/files/' + pathToHash[relFile]
       else return pathToHash[relFile]
     })
   )


### PR DESCRIPTION
Moving fetch() to lib is part of #36. To goal is to simplify the service worker so it's easy to customize while providing the right set of tools in the lib. 

The big issue encountered with this was after moving fetch() to lib is, it was not possible to differentiate between requests for planktos assets (plankots.min.js, root.torrent, etc) from webseed requests within the service worker. Not being able to differentiate these forced the service worker to handle webseed requests instead of the browser which had a big performance impact (downloads were 2-3x slower). By changing webseed request urls to `<origin>/planktos/files/<hash>` instead of `<origin>/planktos/<hash>` the service worker can detect the webseed request and let the browser handle it instead. This required copying the website files to `planktos/files` instead of `planktos`.