### PR TITLE
Add web stream and RANGE header support

### DIFF
--- a/lib/file.js
+++ b/lib/file.js
@@ -16,20 +16,19 @@ function File (snapshot, fpath, fileInfo) {
   }
 }
 
-File.prototype.getStream = function () {
+File.prototype.getStream = function (opts) {
+  if (!opts) opts = {}
   this._snapshot._priority.add(this.hash) // TODO only add if necessary
 
-  if (this.length === 0) throw new Error('Cannot read empty file')
-
   return Promise.resolve(new ChunkStream(this._snapshot._chunkStore, {
-    start: this.offset,
-    end: this.offset + this.length - 1,
+    start: this.offset + (opts.start || 0),
+    end: this.offset + (opts.end || (this.length - 1)),
     onmiss: this._onChunkMiss.bind(this)
   }))
 }
 
-File.prototype.getBlob = function () {
-  return this.getStream()
+File.prototype.getBlob = function (opts) {
+  return this.getStream(opts)
   .then(stream => {
     return new Promise(function (resolve, reject) {
       toBlob(stream, function (err, blob) {

--- a/lib/file.js
+++ b/lib/file.js
@@ -1,7 +1,11 @@
 module.exports = File
 
+/* global ReadableStream */
+
 const ChunkStream = require('chunk-store-read-stream')
 const toBlob = require('stream-to-blob')
+
+File.WEBSTREAM_SUPPORT = typeof ReadableStream !== 'undefined'
 
 function File (snapshot, fpath, fileInfo) {
   this.path = fpath
@@ -17,14 +21,57 @@ function File (snapshot, fpath, fileInfo) {
 }
 
 File.prototype.getStream = function (opts) {
-  if (!opts) opts = {}
-  this._snapshot._priority.add(this.hash) // TODO only add if necessary
+  opts = opts || {}
+  let start = opts.start || 0
+  let end = opts.end || (this.length - 1)
+
+  if (start < 0 || end < 0 || start > this.length - 1 || end > this.length - 1) {
+    throw new Error('Range out of bounds')
+  }
+
+  if (this.length === 0) throw new Error('Cannot read empty file')
+
+  // Add in the file's byte offset inside the torrent
+  start += this.offset
+  end += this.offset
+
+  this._snapshot._priority.add({ start: start, end: end }) // TODO only add if necessary
 
   return Promise.resolve(new ChunkStream(this._snapshot._chunkStore, {
-    start: this.offset + (opts.start || 0),
-    end: this.offset + (opts.end || (this.length - 1)),
+    start: start,
+    end: end,
     onmiss: this._onChunkMiss.bind(this)
   }))
+}
+
+File.prototype.getWebStream = function (opts) {
+  if (!File.WEBSTREAM_SUPPORT) throw new Error('No web ReadableStream support')
+
+  opts = opts || {}
+  return this.getStream(opts)
+  .then(stream => {
+    let webStream = new ReadableStream({start: start, pull: pull, cancel: cancel})
+    webStream.length = (opts.end || (this.length - 1)) - (opts.start || 0) + 1
+    return webStream
+
+    function start (controller) {
+      stream.on('data', chunk => {
+        controller.enqueue(chunk)
+        stream.pause()
+      })
+      stream.on('end', () => controller.close())
+      stream.on('error', (e) => controller.error(e))
+      stream.pause()
+    }
+
+    function pull () {
+      stream.resume()
+    }
+
+    function cancel () {
+      stream.destroy()
+    }
+  })
 }
 
 File.prototype.getBlob = function (opts) {

--- a/lib/seeder.js
+++ b/lib/seeder.js
@@ -79,28 +79,15 @@ Seeder.prototype._seed = function (snapshot) {
   })
 }
 
-Seeder.prototype._prioritize = function (snapshot, hash) {
+Seeder.prototype._prioritize = function (snapshot, range) {
   if (this.destroyed || this._webtorrent == null) return
-  if (hash.value) hash = hash.value
-  let torrentMeta = snapshot.torrentMeta
-  let fileInfo = torrentMeta.files.find(f => f.name === hash)
-  let start = Math.floor(fileInfo.offset / torrentMeta.pieceLength)
-  let end = Math.floor((fileInfo.offset + fileInfo.length - 1) / torrentMeta.pieceLength)
-  let torrent = this._webtorrent.get(torrentMeta.infoHash)
+  if (range.value) range = range.value
 
-  if (torrent == null) return // Webtorrent has not finished initializing
+  let start = Math.floor(range.start / snapshot.torrentMeta.pieceLength)
+  let end = Math.floor(range.end / snapshot.torrentMeta.pieceLength)
+  let torrent = this._webtorrent.get(snapshot.torrentMeta.infoHash)
 
-  let file = torrent.files.find(f => f.name === hash)
-
-  if (file.downloaded !== file.length) {
-    torrent.select(start, end, 1)
-  } else {
-    var transaction = snapshot._priority.transaction()
-    transaction.json().then(json => {
-      var rm = Object.keys(json).filter(k => json[k] === hash)
-      rm.forEach(k => transaction.remove(k))
-    })
-  }
+  if (torrent != null && torrent.progress !== 1) torrent.select(start, end, 1)
 }
 
 Seeder.prototype.destroy = function () {

--- a/lib/snapshot.js
+++ b/lib/snapshot.js
@@ -44,6 +44,12 @@ Snapshot.prototype.fetch = function (req, opts) {
   opts = opts || {}
   let inject = false
   let url = null
+  let range = null
+  let responseMeta = {
+    status: 200,
+    statusText: 'OK',
+    headers: { 'Accept-Ranges': 'bytes' }
+  }
 
   // Convert a FetchEvent to Request
   if (global.FetchEvent && req instanceof global.FetchEvent) {
@@ -57,6 +63,12 @@ Snapshot.prototype.fetch = function (req, opts) {
     inject = inject && url.search.substr(1)
              .split('&').find(s => s === 'noPlanktosInjection') == null
     if (req.method !== 'GET') throw new Error('Only HTTP GET requests supported')
+
+    let rangeHeader = /^bytes=(\d+)-(\d+)?$/g.exec(req.headers.get('range'))
+    if (rangeHeader && rangeHeader[1]) {
+      range = { start: Number(rangeHeader[1]) }
+      if (rangeHeader[2]) range.end = Number(rangeHeader[2])
+    }
   } else if (req instanceof URL) {
     url = req
   } else if (typeof req === 'string') {
@@ -84,7 +96,15 @@ Snapshot.prototype.fetch = function (req, opts) {
     let fpath = opts.root ? url.pathname.replace(opts.root, '') : url.pathname
     let file = this.getFile(fpath)
     if (file != null) {
-      blobPromise = file.getBlob()
+      if (range && (!range.end || range.end > file.length - 1)) range.end = file.length - 1
+      if (range && range.start > range.end) range = null // Invalid range so ignore it
+
+      if (range) {
+        responseMeta.status = 206
+        responseMeta.statusText = 'Partial Content'
+        responseMeta.headers['Content-Range'] = 'bytes ' + range.start + '-' + range.end + '/' + file.length
+      }
+      blobPromise = file.getBlob(range)
     } else {
       blobPromise = global.caches.open('planktos')
         .then(c => c.match(url.pathname))
@@ -92,8 +112,11 @@ Snapshot.prototype.fetch = function (req, opts) {
     }
   }
 
-  return blobPromise
-  .then(blob => blob != null ? new Response(blob) : undefined)
+  return blobPromise.then(blob => {
+    if (blob == null) return undefined
+    responseMeta.headers['Content-Length'] = blob.size
+    return new Response(blob, responseMeta)
+  })
 }
 
 Snapshot.prototype.close = function () {

--- a/lib/snapshot.js
+++ b/lib/snapshot.js
@@ -45,7 +45,7 @@ Snapshot.prototype.fetch = function (req, opts) {
   req = parseRequest(req)
 
   let range = req.range
-  let blobPromise = null
+  let bodyPromise = null
   let fpath = opts.root ? req.url.pathname.replace(opts.root, '') : req.url.pathname
   let file = this.getFile(fpath)
   let responseMeta = {
@@ -57,7 +57,7 @@ Snapshot.prototype.fetch = function (req, opts) {
   if (req.url.origin !== global.location.origin) throw new Error('Cannot Fetch. Origin differs')
 
   if (opts.inject != null ? opts.inject : req.inject) {
-    blobPromise = Promise.resolve(createInjection(req.url, opts.root))
+    bodyPromise = Promise.resolve(createInjection(req.url, opts.root))
   } else if (file != null) {
     if (range && (!range.end || range.end > file.length - 1)) range.end = file.length - 1
     if (range && range.start > range.end) range = null // Invalid range so ignore it
@@ -69,17 +69,18 @@ Snapshot.prototype.fetch = function (req, opts) {
                                               range.end + '/' + file.length
     }
 
-    blobPromise = file.getBlob(range)
+    let shouldStream = opts.stream != null ? opts.stream : File.WEBSTREAM_SUPPORT
+    bodyPromise = shouldStream ? file.getWebStream(range) : file.getBlob(range)
   } else {
-    blobPromise = global.caches.open('planktos')
+    bodyPromise = global.caches.open('planktos')
     .then(c => c.match(req.url.pathname))
     .then(resp => resp ? resp.blob() : undefined)
   }
 
-  return blobPromise.then(blob => {
-    if (blob == null) return undefined
-    responseMeta.headers['Content-Length'] = blob.size
-    return new Response(blob, responseMeta)
+  return bodyPromise.then(body => {
+    if (body == null) return undefined
+    responseMeta.headers['Content-Length'] = body.size || body.length
+    return new Response(body, responseMeta)
   })
 }
 

--- a/lib/snapshot.js
+++ b/lib/snapshot.js
@@ -42,14 +42,62 @@ Snapshot.prototype.getFile = function (fpath) {
 Snapshot.prototype.fetch = function (req, opts) {
   if (this.closed) throw new Error('Snapshot is closed')
   opts = opts || {}
-  let inject = false
-  let url = null
-  let range = null
+  req = parseRequest(req)
+
+  let range = req.range
+  let blobPromise = null
+  let fpath = opts.root ? req.url.pathname.replace(opts.root, '') : req.url.pathname
+  let file = this.getFile(fpath)
   let responseMeta = {
     status: 200,
     statusText: 'OK',
     headers: { 'Accept-Ranges': 'bytes' }
   }
+
+  if (req.url.origin !== global.location.origin) throw new Error('Cannot Fetch. Origin differs')
+
+  if (opts.inject != null ? opts.inject : req.inject) {
+    blobPromise = Promise.resolve(createInjection(req.url, opts.root))
+  } else if (file != null) {
+    if (range && (!range.end || range.end > file.length - 1)) range.end = file.length - 1
+    if (range && range.start > range.end) range = null // Invalid range so ignore it
+
+    if (range) {
+      responseMeta.status = 206
+      responseMeta.statusText = 'Partial Content'
+      responseMeta.headers['Content-Range'] = 'bytes ' + range.start + '-' +
+                                              range.end + '/' + file.length
+    }
+
+    blobPromise = file.getBlob(range)
+  } else {
+    blobPromise = global.caches.open('planktos')
+    .then(c => c.match(req.url.pathname))
+    .then(resp => resp ? resp.blob() : undefined)
+  }
+
+  return blobPromise.then(blob => {
+    if (blob == null) return undefined
+    responseMeta.headers['Content-Length'] = blob.size
+    return new Response(blob, responseMeta)
+  })
+}
+
+Snapshot.prototype.close = function () {
+  if (this.closed) return
+  this.closed = true
+
+  this._priority.close()
+  this._priority = null
+
+  this._chunkStore.close()
+  this._chunkStore = null
+}
+
+function parseRequest (req) {
+  let inject = false
+  let url = null
+  let range = null
 
   // Convert a FetchEvent to Request
   if (global.FetchEvent && req instanceof global.FetchEvent) {
@@ -76,56 +124,21 @@ Snapshot.prototype.fetch = function (req, opts) {
   }
 
   if (url == null) throw new Error('Must provide a FetchEvent, Request, URL, or a url string')
-  if (url.origin !== global.location.origin) throw new Error('Cannot Fetch. Origin differs')
 
-  inject = 'inject' in opts ? opts.inject : inject
-
-  // Generate response blob. Depends on if the downloader should be injected or not
-  let blobPromise = null
-  if (inject) {
-    let fname = url.pathname.substr(url.pathname.lastIndexOf('/') + 1)
-    const isHTML = fname.endsWith('.html') || fname.endsWith('.htm') || !fname.includes('.')
-    let modUrl = new URL(url.toString())
-    modUrl.search = (modUrl.search === '' ? '?' : modUrl.search + '&') + 'noPlanktosInjection'
-    let html = (isHTML ? injection.docWrite : injection.iframe)
-               .replace(/{{url}}/g, modUrl.toString())
-               .replace(/{{root}}/g, opts.root ? opts.root : '')
-    blobPromise = Promise.resolve(new Blob([html], {type: 'text/html'}))
-  } else {
-    // fpath is relative to the service worker scope if opts.root was given
-    let fpath = opts.root ? url.pathname.replace(opts.root, '') : url.pathname
-    let file = this.getFile(fpath)
-    if (file != null) {
-      if (range && (!range.end || range.end > file.length - 1)) range.end = file.length - 1
-      if (range && range.start > range.end) range = null // Invalid range so ignore it
-
-      if (range) {
-        responseMeta.status = 206
-        responseMeta.statusText = 'Partial Content'
-        responseMeta.headers['Content-Range'] = 'bytes ' + range.start + '-' + range.end + '/' + file.length
-      }
-      blobPromise = file.getBlob(range)
-    } else {
-      blobPromise = global.caches.open('planktos')
-        .then(c => c.match(url.pathname))
-        .then(resp => resp ? resp.blob() : undefined)
-    }
+  return {
+    inject: inject,
+    url: url,
+    range: range
   }
-
-  return blobPromise.then(blob => {
-    if (blob == null) return undefined
-    responseMeta.headers['Content-Length'] = blob.size
-    return new Response(blob, responseMeta)
-  })
 }
 
-Snapshot.prototype.close = function () {
-  if (this.closed) return
-  this.closed = true
-
-  this._priority.close()
-  this._priority = null
-
-  this._chunkStore.close()
-  this._chunkStore = null
+function createInjection (url, root) {
+  let fname = url.pathname.substr(url.pathname.lastIndexOf('/') + 1)
+  const isHTML = fname.endsWith('.html') || fname.endsWith('.htm') || !fname.includes('.')
+  let modUrl = new URL(url.toString())
+  modUrl.search = (modUrl.search === '' ? '?' : modUrl.search + '&') + 'noPlanktosInjection'
+  let html = (isHTML ? injection.docWrite : injection.iframe)
+             .replace(/{{url}}/g, modUrl.toString())
+             .replace(/{{root}}/g, root != null ? root : '')
+  return new Blob([html], {type: 'text/html'})
 }


### PR DESCRIPTION
With this PR, streaming within Chrome is possible. Browsers that do not have the ReadableStream api, default to using blobs. Streaming can be disabled by setting `opts.stream = false` when calling fetch().

The way files are prioritized has changed because ranges of a file can be requested. So instead of storing the file's name/hash in the priority store, the prioritized byte range is stored instead.

There does seem to be weird issues with video streaming though, but I feel mostly confident the issues are not with planktos but with browser vendors.

* Chrome sometimes fails to play videos served by the sw (streams and blobs) with a `MediaEvent: PIPELINE_ERROR pipeline: read error`. 
* ~~Sometimes requests for videos do not get intercepted by the sw in Firefox (maybe this is a good thing lol).~~ This turns out to be expected behavior in Firefox. When the page initially loads (before the sw is installed) the video is requested and cached. So when the sw activates and the video is requested, the browser just retrieves the video from cache instead of requesting it through the sw. 