### PR TITLE
Change api to export class and expose multiple snapshots

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "docs"]
-	path = docs
-	url = git@github.com:xuset/planktos.wiki.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "docs"]
+	path = docs
+	url = git@github.com:xuset/planktos.wiki.git

--- a/README.md
+++ b/README.md
@@ -76,6 +76,10 @@ Blocking Issues:
  * No streaming support. The requested file must be downloaded in it's entirety before it can be displayed to the user. Currently, only chrome supports streaming from service workers while Firefox has an [open issue](https://bugzilla.mozilla.org/show_bug.cgi?id=1128959) for it.
  * Sharding into multiple torrents is not currently supported, so Planktos will be infeasible for large websites
 
+## Documentation
+
+[Read the docs here](docs/Home.md)
+
 ## Contribute
 
 Contributions are always welcome!

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Blocking Issues:
 
 ## Documentation
 
-[Read the docs here](docs/Home.md)
+[Read the docs here](https://github.com/xuset/planktos/wiki)
 
 ## Contribute
 

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -9,7 +9,7 @@ rm build/* || true
 
 # Build lib
 
-browserify index.js --debug -s planktos \
+browserify index.js --debug -s Planktos \
  | exorcist build/planktos.js.map \
  > build/planktos.js
 

--- a/index.js
+++ b/index.js
@@ -1,13 +1,9 @@
+module.exports = Planktos
+
 const global = typeof window !== 'undefined' ? window : self // eslint-disable-line
 
 // Temp bug fix: https://github.com/srijs/rusha/issues/39
 if (global.WorkerGlobalScope) delete global.FileReaderSync
-
-module.exports.update = update
-module.exports.getSnapshot = getSnapshot
-module.exports.getFile = getFile
-module.exports.fetch = fetch
-module.exports.startSeeder = startSeeder
 
 const IdbKvStore = require('idb-kv-store')
 const path = require('path')
@@ -16,43 +12,47 @@ const TabElect = require('tab-elect')
 const Snapshot = require('./lib/snapshot')
 const Seeder = require('./lib/seeder')
 
-let latestSnapshot = null
-let snapshotPromise = null
-let snapshotStore = new IdbKvStore('planktos-snapshots')
-let seeder = null
-
 const preCached = [
   '/planktos/planktos.min.js',
   '/planktos/install.js'
 ]
 
-function getFile (fpath) {
-  return getSnapshot()
+function Planktos () {
+  this._latestSnapshot = null
+  this._snapshotPromise = null
+  this._snapshotStore = new IdbKvStore('planktos-snapshots')
+  this._seeder = null
+}
+
+Planktos.prototype.getFile = function (fpath) {
+  return this.getSnapshot()
   .then(snapshot => snapshot.getFile(fpath))
 }
 
-function fetch (req, opts) {
-  return getSnapshot()
+Planktos.prototype.fetch = function (req, opts) {
+  return this.getSnapshot()
   .then(snapshot => snapshot.fetch(req, opts))
 }
 
-function getSnapshot () {
-  if (latestSnapshot) return Promise.resolve(latestSnapshot)
-  if (snapshotPromise) return snapshotPromise
+Planktos.prototype.getSnapshot = function () {
+  let self = this
+  if (self._latestSnapshot) return Promise.resolve(self._latestSnapshot)
+  if (self._snapshotPromise) return self._snapshotPromise
 
-  snapshotPromise = snapshotStore.get('latest')
+  self._snapshotPromise = self._snapshotStore.get('latest')
   .then(latest => {
-    snapshotPromise = null
+    self._snapshotPromise = null
     if (latest == null) throw new Error('No local snapshot. Call planktos.update()')
-    latestSnapshot = new Snapshot(latest)
-    if (seeder) seeder.add(latestSnapshot)
-    return latestSnapshot
+    self._latestSnapshot = new Snapshot(latest)
+    if (self._seeder) self._seeder.add(self._latestSnapshot)
+    return self._latestSnapshot
   })
 
-  return snapshotPromise
+  return self._snapshotPromise
 }
 
-function update (rootUrl) {
+Planktos.prototype.update = function (rootUrl) {
+  let self = this
   if (!(rootUrl instanceof URL)) rootUrl = new URL(rootUrl, global.location.origin)
 
   let torrentMetaUrl = new URL(path.join(rootUrl.pathname, 'planktos/root.torrent'), rootUrl)
@@ -62,7 +62,7 @@ function update (rootUrl) {
   return Promise.all([
     global.fetch(manifestUrl).then(response => response.json()),
     global.fetch(torrentMetaUrl).then(response => response.arrayBuffer()),
-    snapshotStore.get('latest'),
+    self._snapshotStore.get('latest'),
     global.caches.open('planktos').then(cache => cache.addAll(cacheUrls))
   ])
   .then(results => {
@@ -79,35 +79,36 @@ function update (rootUrl) {
     }
 
     return Promise.all([
-      snapshotStore.set('latest', snapshotObj),
-      snapshotStore.set(hash, snapshotObj)
+      self._snapshotStore.set('latest', snapshotObj),
+      self._snapshotStore.set(hash, snapshotObj)
     ])
   })
   .then(() => {
-    if (latestSnapshot) latestSnapshot.close()
-    latestSnapshot = null
-    snapshotPromise = null
-    return getSnapshot()
+    if (self._latestSnapshot) self._latestSnapshot.close()
+    self._latestSnapshot = null
+    self._snapshotPromise = null
+    return self.getSnapshot()
   })
 }
 
-function startSeeder () {
-  if (seeder) return seeder
-  seeder = new Seeder()
+Planktos.prototype.startSeeder = function () {
+  let self = this
+  if (self._seeder) return self._seeder
+  self._seeder = new Seeder()
 
   let tabElect = new TabElect('planktos')
-  tabElect.on('elected', seeder.start.bind(seeder))
-  tabElect.on('deposed', seeder.stop.bind(seeder))
+  tabElect.on('elected', self._seeder.start.bind(self._seeder))
+  tabElect.on('deposed', self._seeder.stop.bind(self._seeder))
 
-  snapshotStore.on('set', function (change) {
-    if (change.key !== 'latest') seeder.add(new Snapshot(change.value))
+  self._snapshotStore.on('set', function (change) {
+    if (change.key !== 'latest') self._seeder.add(new Snapshot(change.value))
   })
 
-  snapshotStore.json().then(json => {
+  self._snapshotStore.json().then(json => {
     Object.keys(json)
     .filter(hash => hash !== 'latest')
-    .forEach(hash => seeder.add(new Snapshot(json[hash])))
+    .forEach(hash => self._seeder.add(new Snapshot(json[hash])))
   })
 
-  return seeder
+  return self._seeder
 }

--- a/index.js
+++ b/index.js
@@ -27,20 +27,18 @@ function Planktos (opts) {
 }
 
 Planktos.prototype.getFile = function (fpath) {
-  return this.getSnapshot()
-  .then(snapshot => snapshot.getFile(fpath))
+  return this.getAllSnapshots()
+  .then(snapshots => {
+    if (snapshots.length === 0) throw new Error('No local snapshot. Call planktos.update()')
+    return snapshots[snapshots.length - 1].getFile(fpath)
+  })
 }
 
 Planktos.prototype.fetch = function (req, opts) {
-  return this.getSnapshot()
-  .then(snapshot => snapshot.fetch(req, opts))
-}
-
-Planktos.prototype.getSnapshot = function () {
-  return this.getAllSnapshots().then(snapshots => {
-    let latest = snapshots[snapshots.length - 1]
-    if (latest == null) throw new Error('No local snapshot. Call planktos.update()')
-    return latest
+  return this.getAllSnapshots()
+  .then(snapshots => {
+    if (snapshots.length === 0) throw new Error('No local snapshot. Call planktos.update()')
+    return snapshots[snapshots.length - 1].fetch(req, opts)
   })
 }
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -9,8 +9,8 @@ module.exports = function (config) {
 
     // list of files / patterns to load in the browser
     files: [
-      './build/test.js',
       './test/www/v1/planktos/planktos.min.js',
+      './build/test.js',
       {
         pattern: './test/www/**',
         included: false,

--- a/lib/injection.js
+++ b/lib/injection.js
@@ -14,7 +14,7 @@ module.exports.iframe = `\
   <iframe id="tree" name="tree" src="{{url}}" frameborder="0" marginheight="0" marginwidth="0" width="100%" height="100%" scrolling="auto"></iframe>
   <script src="{{root}}/planktos/planktos.min.js"></script>
   <script>
-    planktos.startSeeder()
+    new Planktos().startSeeder()
   </script>
 </body>
 </html>
@@ -27,7 +27,7 @@ module.exports.docWrite = `\
   <meta charset="utf-8">
   <script src="{{root}}/planktos/planktos.min.js"></script>
   <script>
-    planktos.startSeeder()
+    new Planktos().startSeeder()
     fetch('{{url}}')
     .then(resp => resp.text())
     .then(text => {

--- a/lib/seeder.js
+++ b/lib/seeder.js
@@ -15,7 +15,7 @@ function Seeder () {
 
 Seeder.prototype.add = function (snapshot) {
   if (this.destroyed) throw new Error('Seeder has been destroyed')
-  if (snapshot.hash in this._seeds) return
+  if (snapshot.closed || snapshot.hash in this._seeds) return
 
   let listener = this._prioritize.bind(this, snapshot)
 
@@ -30,6 +30,19 @@ Seeder.prototype.add = function (snapshot) {
   }
 }
 
+Seeder.prototype.remove = function (hash) {
+  if (this.destroyed) throw new Error('Seeder has been destroyed')
+
+  let seed = this._seeds[hash]
+  delete this._seeds[hash]
+
+  if (this._webtorrent) this._webtorrent.remove(seed.snapshot.torrentMetaBuffer)
+
+  if (seed != null && !seed.snapshot.closed) {
+    seed.snapshot._priority.removeListener('add', this._seeds[hash].listener)
+  }
+}
+
 Seeder.prototype.start = function () {
   if (this.destroyed) throw new Error('Seeder is destroyed')
   if (this.started) return
@@ -38,8 +51,13 @@ Seeder.prototype.start = function () {
   this._webtorrent = this._webtorrent || new WebTorrent()
 
   for (let hash in this._seeds) {
-    this._seeds[hash].snapshot._priority.on('add', this._seeds[hash].listener)
-    this._seed(this._seeds[hash].snapshot)
+    let snapshot = this._seeds[hash].snapshot
+    if (snapshot.closed) {
+      delete this._seeds[hash]
+    } else {
+      snapshot._priority.on('add', this._seeds[hash].listener)
+      this._seed(snapshot)
+    }
   }
 }
 
@@ -51,7 +69,9 @@ Seeder.prototype.stop = function () {
   this._webtorrent = null
 
   for (let hash in this._seeds) {
-    this._seeds[hash].snapshot._priority.removeListener('add', this._seeds[hash].listener)
+    let snapshot = this._seeds[hash].snapshot
+    if (snapshot.closed) delete this._seeds[hash]
+    else snapshot._priority.removeListener('add', this._seeds[hash].listener)
   }
 }
 
@@ -61,7 +81,7 @@ Seeder.prototype._seed = function (snapshot) {
 
   let opts = {store: IdbChunkStore}
   self._webtorrent.add(snapshot.torrentMetaBuffer, opts, function (torrent) {
-    if (self.destroyed) return
+    if (snapshot.closed || self.destroyed) return
     if (torrent.urlList.length === 0) {
       const isSingleFile = torrent.files.length === 1
       let url = new URL(snapshot.rootUrl)
@@ -74,13 +94,14 @@ Seeder.prototype._seed = function (snapshot) {
     .then(values => values.forEach(v => self._prioritize(snapshot, v)))
 
     torrent.on('done', function () {
+      if (snapshot.closed || self.destroyed) return
       snapshot._priority.clear()
     })
   })
 }
 
 Seeder.prototype._prioritize = function (snapshot, range) {
-  if (this.destroyed || this._webtorrent == null) return
+  if (snapshot.closed || this.destroyed || this._webtorrent == null) return
   if (range.value) range = range.value
 
   let start = Math.floor(range.start / snapshot.torrentMeta.pieceLength)

--- a/lib/snapshot.js
+++ b/lib/snapshot.js
@@ -9,7 +9,7 @@ const File = require('./file')
 
 const global = typeof window !== 'undefined' ? window : self // eslint-disable-line
 
-function Snapshot (obj) {
+function Snapshot (obj, namespace) {
   this.closed = false
   this.manifest = obj.manifest
   this.torrentMetaBuffer = Buffer.isBuffer(obj.torrentMetaBuffer)
@@ -18,7 +18,8 @@ function Snapshot (obj) {
   this.hash = obj.hash
   this.rootUrl = obj.rootUrl
 
-  this._priority = new IdbKvStore('planktos-priority-' + this.hash)
+  this._namespace = namespace
+  this._priority = new IdbKvStore('planktos-priority-' + this.hash + '-' + namespace)
   this._missingChunks = null
   this._chunkStore = new IdbChunkStore(this.torrentMeta.pieceLength, {
     name: this.hash
@@ -72,7 +73,7 @@ Snapshot.prototype.fetch = function (req, opts) {
     let shouldStream = opts.stream != null ? opts.stream : File.WEBSTREAM_SUPPORT
     bodyPromise = shouldStream ? file.getWebStream(range) : file.getBlob(range)
   } else {
-    bodyPromise = global.caches.open('planktos')
+    bodyPromise = global.caches.open('planktos-' + this._namespace)
     .then(c => c.match(req.url.pathname))
     .then(resp => resp ? resp.blob() : undefined)
   }

--- a/lib/snapshot.js
+++ b/lib/snapshot.js
@@ -129,7 +129,7 @@ function parseRequest (req) {
   } else if (req instanceof URL) {
     url = req
   } else if (typeof req === 'string') {
-    url = new URL(req)
+    url = new URL(req, global.location.origin)
   }
 
   if (url == null) throw new Error('Must provide a FetchEvent, Request, URL, or a url string')

--- a/lib/snapshot.js
+++ b/lib/snapshot.js
@@ -19,7 +19,8 @@ function Snapshot (obj, namespace) {
   this.rootUrl = obj.rootUrl
 
   this._namespace = namespace
-  this._priority = new IdbKvStore('planktos-priority-' + this.hash + '-' + namespace)
+  this._priorityDbName = 'planktos-priority-' + this.hash + '-' + namespace
+  this._priority = new IdbKvStore(this._priorityDbName)
   this._missingChunks = null
   this._chunkStore = new IdbChunkStore(this.torrentMeta.pieceLength, {
     name: this.hash
@@ -94,6 +95,12 @@ Snapshot.prototype.close = function () {
 
   this._chunkStore.close()
   this._chunkStore = null
+}
+
+Snapshot.prototype.destroy = function () {
+  this.close()
+  global.indexedDB.deleteDatabase(this.hash)
+  global.indexedDB.deleteDatabase(this._priorityDbName)
 }
 
 function parseRequest (req) {

--- a/sw.js
+++ b/sw.js
@@ -1,11 +1,12 @@
 /* eslint-env browser, serviceworker */
-/* global planktos */
+/* global Planktos */
 
 importScripts('planktos/planktos.min.js')
-// or require('planktos')
+// or const Planktos = require('planktos')
 
 // The location of the planktos root directory
 const root = location.pathname.substring(0, location.pathname.lastIndexOf('/'))
+const planktos = new Planktos()
 
 addEventListener('install', function (event) {
   event.waitUntil(planktos.update(root))

--- a/test/test.js
+++ b/test/test.js
@@ -24,13 +24,8 @@ describe('lib', function () {
   it('getAllSnapshots()', function () {
     return planktos.getAllSnapshots()
     .then(snapshots => {
-      assert.deepEqual(snapshots.length, 1)
-    })
-  })
-
-  it('getSnapshot()', function () {
-    return planktos.getSnapshot()
-    .then(snapshot => {
+      assert.equal(snapshots.length, 1)
+      let snapshot = snapshots[0]
       let parsed = parseTorrent(snapshot.torrentMetaBuffer)
       assert.equal(parsed.infoHash, snapshot.torrentMeta.infoHash)
       assert.equal(snapshot.hash, snapshot.torrentMeta.infoHash)

--- a/test/test.js
+++ b/test/test.js
@@ -12,19 +12,19 @@ describe('lib', function () {
   this.timeout(20000)
 
   it('getAllSnapshots() - empty', function () {
-    return planktos.getAllSnapshots().then(snapshots => assert.deepEqual(snapshots, {}))
+    return planktos.getAllSnapshots().then(snapshots => assert.deepEqual(snapshots, []))
   })
 
   it('update() to v1', function () {
     return planktos.update(v1Base)
+    .then(snapshot => assert('hash' in snapshot))
     .then(() => planktos.startSeeder())
   })
 
   it('getAllSnapshots()', function () {
     return planktos.getAllSnapshots()
     .then(snapshots => {
-      assert.deepEqual(Object.keys(snapshots).length, 2)
-      assert('latest' in snapshots)
+      assert.deepEqual(snapshots.length, 1)
     })
   })
 
@@ -434,14 +434,15 @@ describe('lib', function () {
 
   it('update() to v2', function () {
     return planktos.update(v2Base)
+    .then(snapshot => assert('hash' in snapshot))
     .then(() => planktos.startSeeder())
   })
 
   it('v2 - getAllSnapshots()', function () {
     return planktos.getAllSnapshots()
     .then(snapshots => {
-      assert.equal(Object.keys(snapshots).length, 3)
-      let snapshot = snapshots['latest']
+      assert.equal(snapshots.length, 2)
+      let snapshot = snapshots[1]
       let parsed = parseTorrent(snapshot.torrentMetaBuffer)
       assert.equal(parsed.infoHash, snapshot.torrentMeta.infoHash)
       assert.equal(snapshot.hash, snapshot.torrentMeta.infoHash)

--- a/test/test.js
+++ b/test/test.js
@@ -1,11 +1,12 @@
 /* eslint-env mocha, browser */
-/* global planktos */
+/* global Planktos */
 
 const assert = require('assert')
 const parseTorrent = require('parse-torrent-file')
 
 const v1Base = '/base/test/www/v1/'
 const v2Base = '/base/test/www/v2/'
+const planktos = new Planktos()
 
 describe('lib', function () {
   this.timeout(20000)

--- a/test/test.js
+++ b/test/test.js
@@ -6,7 +6,7 @@ const parseTorrent = require('parse-torrent-file')
 
 const v1Base = '/base/test/www/v1/'
 const v2Base = '/base/test/www/v2/'
-const planktos = new Planktos()
+const planktos = new Planktos({ namespace: Math.random() })
 
 describe('lib', function () {
   this.timeout(20000)

--- a/test/test.js
+++ b/test/test.js
@@ -11,9 +11,21 @@ const planktos = new Planktos({ namespace: Math.random() })
 describe('lib', function () {
   this.timeout(20000)
 
-  before(function () {
+  it('getAllSnapshots() - empty', function () {
+    return planktos.getAllSnapshots().then(snapshots => assert.deepEqual(snapshots, {}))
+  })
+
+  it('update() to v1', function () {
     return planktos.update(v1Base)
     .then(() => planktos.startSeeder())
+  })
+
+  it('getAllSnapshots()', function () {
+    return planktos.getAllSnapshots()
+    .then(snapshots => {
+      assert.deepEqual(Object.keys(snapshots).length, 2)
+      assert('latest' in snapshots)
+    })
   })
 
   it('getSnapshot()', function () {
@@ -425,9 +437,11 @@ describe('lib', function () {
     .then(() => planktos.startSeeder())
   })
 
-  it('v2 - getSnapshot()', function () {
-    return planktos.getSnapshot()
-    .then(snapshot => {
+  it('v2 - getAllSnapshots()', function () {
+    return planktos.getAllSnapshots()
+    .then(snapshots => {
+      assert.equal(Object.keys(snapshots).length, 3)
+      let snapshot = snapshots['latest']
       let parsed = parseTorrent(snapshot.torrentMetaBuffer)
       assert.equal(parsed.infoHash, snapshot.torrentMeta.infoHash)
       assert.equal(snapshot.hash, snapshot.torrentMeta.infoHash)

--- a/test/test.js
+++ b/test/test.js
@@ -183,6 +183,19 @@ describe('lib', function () {
     .then(text => assert.equal(text, 'foobar\n'))
   })
 
+  it('planktos.fetch() with relative string url', function () {
+    return planktos.fetch('foobar.txt')
+    .then(response => {
+      assert.equal(response.status, 200)
+      assert.equal(response.statusText, 'OK')
+      assert.equal(response.headers.get('Content-Length'), '7')
+      assert.equal(response.headers.get('Accept-Ranges'), 'bytes')
+      return response.blob()
+    })
+    .then(blob => blobToText(blob))
+    .then(text => assert.equal(text, 'foobar\n'))
+  })
+
   it('planktos.fetch() implied index html', function () {
     return planktos.fetch(location.origin + v1Base + 'foo', {root: v1Base})
     .then(response => {


### PR DESCRIPTION
The big change was exporting a class instead of an instance. This aligns planktos better with best practices, and allows for versatility when instantiating.

Before this change, planktos inherently required multiple snapshot support even though the ability to see older snapshots was not available in the public api. This was required because multiple instances could be on multiple snapshots at any given time. So instead of hiding this, a `getAllSnapshots()` method was added to the public api, and the notion of the latest snapshot was removed due to the edge cases surrounding it. To compensate for the removal, getAllSnapshots returns an ordered array with the newer snapshots at higher indexes.

The ability to remove snapshots was also added to the public api. Also usage and api documentation was added to the wiki.

With the addition of an ordered getAllSnapshots() and removeSnapshot(), the planktos instance is aligned with the concept of an ordered list of zero or more snapshots.