### PR TITLE
adding torrent announce list configuration via convict

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "bin": "./bin/setup.js",
   "dependencies": {
     "aether-torrent": "^0.3.0",
+    "convict": "^4.3.2",
     "create-torrent": "^3.29.1",
     "idb-kv-store": "^4.3.1",
     "minimist": "^1.2.0",


### PR DESCRIPTION
note that the default trackers are those from `create-torrent`.

resolves #25